### PR TITLE
Implement pooling of DrawableHitObjects

### DIFF
--- a/osu.Game.Rulesets.Hishigata/Beatmaps/HishigataBeatmap.cs
+++ b/osu.Game.Rulesets.Hishigata/Beatmaps/HishigataBeatmap.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Hishigata.Beatmaps
                     case HishigataBonus _:
                         ++bonus;
                         break;
-                    case HishigataHitObject n:
+                    case HishigataNote n:
                         if (n.IsFeign) ++feigns;
                         else ++notes;
                         break;

--- a/osu.Game.Rulesets.Hishigata/Beatmaps/HishigataBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Hishigata/Beatmaps/HishigataBeatmapConverter.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Hishigata.Beatmaps
                     break;
 
                 default:
-                    yield return new HishigataHitObject
+                    yield return new HishigataNote
                     {
                         Lane = lane,
                         Samples = original.Samples,

--- a/osu.Game.Rulesets.Hishigata/Objects/Drawables/DrawableHishigataBonus.cs
+++ b/osu.Game.Rulesets.Hishigata/Objects/Drawables/DrawableHishigataBonus.cs
@@ -4,7 +4,11 @@ namespace osu.Game.Rulesets.Hishigata.Objects.Drawables
 {
     public class DrawableHishigataBonus : DrawableHishigataHitObject
     {
-        public DrawableHishigataBonus(HishigataHitObject hitObject)
+
+        public DrawableHishigataBonus() : this(null)
+        { }
+
+        public DrawableHishigataBonus(HishigataHitObject hitObject = null)
             : base(hitObject)
         {
             Colour = Color4.Gold;

--- a/osu.Game.Rulesets.Hishigata/Objects/Drawables/DrawableHishigataHitObject.cs
+++ b/osu.Game.Rulesets.Hishigata/Objects/Drawables/DrawableHishigataHitObject.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
@@ -13,17 +15,24 @@ namespace osu.Game.Rulesets.Hishigata.Objects.Drawables
 {
     public class DrawableHishigataHitObject : DrawableHitObject<HishigataHitObject>
     {
-        protected override double InitialLifetimeOffset => HitObject.TimePreempt + (HitObject.IsFeign ? 200 : 0);
+        protected override double InitialLifetimeOffset => HitObject.TimePreempt;
+        protected Container Note;
 
-        private readonly Container note;
-        public DrawableHishigataHitObject(HishigataHitObject hitObject)
+        public DrawableHishigataHitObject() : base(null)
+        {
+        }
+
+        public DrawableHishigataHitObject(HishigataHitObject hitObject = null)
             : base(hitObject)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
         {
             Origin = Anchor.Centre;
             Anchor = Anchor.Centre;
-            Rotation = HitObject.IsFeign ? 180 : 0;
-            Colour = HitObject.IsFeign ? Color4Extensions.FromHex("ff0064") : Color4.White;
-            AddInternal(note = new Container
+            AddInternal(Note = new Container
             {
                 Position = new Vector2(0, -300),
                 Size = new Vector2(50),
@@ -35,6 +44,12 @@ namespace osu.Game.Rulesets.Hishigata.Objects.Drawables
                     Icon = FontAwesome.Solid.ChevronDown,
                 }
             });
+        }
+
+        protected override void OnApply(HitObject hitObject)
+        {
+            base.OnApply(hitObject);
+            LifetimeStart = HitObject.StartTime - InitialLifetimeOffset;
         }
 
         public Func<DrawableHishigataHitObject, bool> CanBeHit;
@@ -52,21 +67,9 @@ namespace osu.Game.Rulesets.Hishigata.Objects.Drawables
                 ApplyResult(r => r.Type = r.Judgement.MinResult);
         }
 
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-            LifetimeStart = HitObject.StartTime - InitialLifetimeOffset;
-        }
-
         protected override void UpdateInitialTransforms()
         {
-            if (HitObject.IsFeign)
-            {
-                note.MoveTo(new Vector2(0, -190), HitObject.TimePreempt * .5).Then().Delay(200).MoveTo(new Vector2(0, -80), HitObject.TimePreempt * .5);
-                this.Delay(HitObject.TimePreempt * .5).Then().RotateTo(360, 200).FadeColour(Color4.White, 200);
-            }
-            else
-                note.MoveTo(new Vector2(0, -80), HitObject.TimePreempt);
+            Note.MoveTo(new Vector2(0, -80), HitObject.TimePreempt);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)
@@ -76,12 +79,12 @@ namespace osu.Game.Rulesets.Hishigata.Objects.Drawables
             switch (state)
             {
                 case ArmedState.Hit:
-                    note.ScaleTo(0, animationDuration).Expire();
+                    Note.ScaleTo(0, animationDuration);
                     this.Delay(animationDuration).Expire();
                     break;
 
                 case ArmedState.Miss:
-                    note.MoveToOffset(new Vector2(0, 80), animationDuration).FadeColour(Color4.Red, animationDuration).FadeOut(animationDuration).Expire();
+                    Note.MoveToOffset(new Vector2(0, 80), animationDuration).FadeColour(Color4.Red, animationDuration).FadeOut(animationDuration);
                     this.Delay(150).Expire();
                     break;
             }

--- a/osu.Game.Rulesets.Hishigata/Objects/Drawables/DrawableHishigataHitObject.cs
+++ b/osu.Game.Rulesets.Hishigata/Objects/Drawables/DrawableHishigataHitObject.cs
@@ -46,12 +46,6 @@ namespace osu.Game.Rulesets.Hishigata.Objects.Drawables
             });
         }
 
-        protected override void OnApply(HitObject hitObject)
-        {
-            base.OnApply(hitObject);
-            LifetimeStart = HitObject.StartTime - InitialLifetimeOffset;
-        }
-
         public Func<DrawableHishigataHitObject, bool> CanBeHit;
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Hishigata/Objects/Drawables/DrawableHishigataNote.cs
+++ b/osu.Game.Rulesets.Hishigata/Objects/Drawables/DrawableHishigataNote.cs
@@ -1,0 +1,42 @@
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Hishigata.Objects.Drawables
+{
+    public class DrawableHishigataNote : DrawableHishigataHitObject
+    {
+        public new HishigataNote HitObject => (HishigataNote)base.HitObject;
+        protected override double InitialLifetimeOffset => HitObject.TimePreempt + (HitObject.IsFeign ? 200 : 0);
+
+        public DrawableHishigataNote() : base(null)
+        {
+        }
+
+        public DrawableHishigataNote(HishigataHitObject hitObject = null)
+            : base(hitObject)
+        {
+        }
+
+        protected override void UpdateInitialTransforms()
+        {
+            LifetimeStart = HitObject.StartTime - InitialLifetimeOffset;
+            if (HitObject.IsFeign)
+            {
+                Note.MoveTo(new Vector2(0, -190), HitObject.TimePreempt * .5).Then().Delay(200).MoveTo(new Vector2(0, -80), HitObject.TimePreempt * .5);
+                this.RotateTo(180).FadeColour(Color4Extensions.FromHex("ff0064")).Delay(HitObject.TimePreempt * .5).Then().RotateTo(360, 200).FadeColour(Color4.White, 200);
+            }
+            else
+                base.UpdateInitialTransforms();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Hishigata/Objects/Drawables/DrawableHishigataPool.cs
+++ b/osu.Game.Rulesets.Hishigata/Objects/Drawables/DrawableHishigataPool.cs
@@ -18,9 +18,9 @@ namespace osu.Game.Rulesets.Hishigata.Objects.Drawables
 
         protected override T CreateNewDrawable() => base.CreateNewDrawable().With(o =>
         {
-            var osuObject = (DrawableHishigataHitObject)(object)o;
+            var hishiObject = (DrawableHishigataHitObject)(object)o;
 
-            osuObject.CanBeHit = checkHittable;
+            hishiObject.CanBeHit = checkHittable;
         });
     }
 }

--- a/osu.Game.Rulesets.Hishigata/Objects/Drawables/DrawableHishigataPool.cs
+++ b/osu.Game.Rulesets.Hishigata/Objects/Drawables/DrawableHishigataPool.cs
@@ -1,0 +1,26 @@
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Pooling;
+using osu.Game.Rulesets.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Hishigata.Objects.Drawables
+{
+    public class DrawableHishigataPool<T> : DrawablePool<T>
+        where T : DrawableHitObject, new()
+    {
+        private readonly Func<DrawableHishigataHitObject, bool> checkHittable;
+
+        public DrawableHishigataPool(Func<DrawableHishigataHitObject, bool> checkHittable, int initialSize, int? maximumSize = null)
+            : base(initialSize, maximumSize)
+        {
+            this.checkHittable = checkHittable;
+        }
+
+        protected override T CreateNewDrawable() => base.CreateNewDrawable().With(o =>
+        {
+            var osuObject = (DrawableHishigataHitObject)(object)o;
+
+            osuObject.CanBeHit = checkHittable;
+        });
+    }
+}

--- a/osu.Game.Rulesets.Hishigata/Objects/HishigataBonus.cs
+++ b/osu.Game.Rulesets.Hishigata/Objects/HishigataBonus.cs
@@ -7,8 +7,6 @@ namespace osu.Game.Rulesets.Hishigata.Objects
 {
     public class HishigataBonus : HishigataHitObject
     {
-        public override bool IsFeign => false;
-
         private static readonly List<HitSampleInfo> samples = new List<HitSampleInfo> { new BonusHitSampleInfo() };
 
         public HishigataBonus()

--- a/osu.Game.Rulesets.Hishigata/Objects/HishigataHitObject.cs
+++ b/osu.Game.Rulesets.Hishigata/Objects/HishigataHitObject.cs
@@ -9,7 +9,6 @@ namespace osu.Game.Rulesets.Hishigata.Objects
 {
     public class HishigataHitObject : HitObject
     {
-        public virtual bool IsFeign { get; set; }
         public double TimePreempt;
 
         public BindableInt LaneBindable = new BindableInt();

--- a/osu.Game.Rulesets.Hishigata/Objects/HishigataNote.cs
+++ b/osu.Game.Rulesets.Hishigata/Objects/HishigataNote.cs
@@ -1,0 +1,14 @@
+using System;
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Rulesets.Hishigata.Objects
+{
+    public class HishigataNote : HishigataHitObject
+    {
+        public bool IsFeign { get; set; }
+    }
+}

--- a/osu.Game.Rulesets.Hishigata/UI/DrawableHishigataRuleset.cs
+++ b/osu.Game.Rulesets.Hishigata/UI/DrawableHishigataRuleset.cs
@@ -25,16 +25,7 @@ namespace osu.Game.Rulesets.Hishigata.UI
 
         protected override ReplayInputHandler CreateReplayInputHandler(Replay replay) => new HishigataFramedReplayInputHandler(replay);
 
-        public override DrawableHitObject<HishigataHitObject> CreateDrawableRepresentation(HishigataHitObject h)
-        {
-            switch (h)
-            {
-                case HishigataBonus _:
-                    return new DrawableHishigataBonus(h);
-                default:
-                    return new DrawableHishigataHitObject(h);
-            }
-        }
+        public override DrawableHitObject<HishigataHitObject> CreateDrawableRepresentation(HishigataHitObject h) => null;
 
         protected override PassThroughInputManager CreateInputManager() => new HishigataInputManager(Ruleset?.RulesetInfo);
 

--- a/osu.Game.Rulesets.Hishigata/UI/HishigataHitObjectLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Hishigata/UI/HishigataHitObjectLifetimeEntry.cs
@@ -1,0 +1,14 @@
+using osu.Game.Rulesets.Hishigata.Objects;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Rulesets.Hishigata.UI
+{
+    public class HishigataHitObjectLifetimeEntry : HitObjectLifetimeEntry
+    {
+        protected override double InitialLifetimeOffset => ((HishigataHitObject)HitObject).TimePreempt + ((isFeign) ? 200 : 0);
+
+        private bool isFeign => HitObject is HishigataNote n && n.IsFeign;
+
+        public HishigataHitObjectLifetimeEntry(HitObject hitObject) : base(hitObject) { }
+    }
+}

--- a/osu.Game.Rulesets.Hishigata/UI/HishigataPlayfield.cs
+++ b/osu.Game.Rulesets.Hishigata/UI/HishigataPlayfield.cs
@@ -4,8 +4,10 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets.Hishigata.Objects;
 using osu.Game.Rulesets.Hishigata.Objects.Drawables;
 using osu.Game.Rulesets.Hishigata.UI.Components;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
 using osuTK;
@@ -20,6 +22,8 @@ namespace osu.Game.Rulesets.Hishigata.UI
 
         private readonly List<Lane> lanes = new List<Lane>();
         private Container playfieldContainer;
+
+        [Cached]
         private PlayerVisual playerObject;
 
         public HishigataPlayfield()
@@ -45,6 +49,12 @@ namespace osu.Game.Rulesets.Hishigata.UI
                 playfieldContainer.Add(lane);
                 AddNested(lane);
             }
+        }
+
+        public override void Add(HitObject hitObject)
+        {
+            var hishiObj = hitObject as HishigataHitObject;
+            lanes[hishiObj.Lane].Add(hitObject);
         }
 
         public override void Add(DrawableHitObject hitObject)

--- a/osu.Game.Rulesets.Hishigata/UI/Lane.cs
+++ b/osu.Game.Rulesets.Hishigata/UI/Lane.cs
@@ -1,11 +1,15 @@
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Hishigata.Objects;
 using osu.Game.Rulesets.Hishigata.Objects.Drawables;
+using osu.Game.Rulesets.Hishigata.UI.Components;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
 using osuTK;
@@ -28,6 +32,17 @@ namespace osu.Game.Rulesets.Hishigata.UI
                 HitObjectContainer,
                 new LaneReceptor{ID = ID}
             });
+            NewResult += onNewResult;
+        }
+
+        private Func<DrawableHishigataHitObject, bool> checkHittable;
+
+        [BackgroundDependencyLoader]
+        private void load(PlayerVisual playerobj)
+        {
+            checkHittable = playerobj.CanBeHit;
+            registerPool<HishigataNote, DrawableHishigataNote>(10);
+            registerPool<HishigataBonus, DrawableHishigataBonus>(10);
         }
 
         public override void Add(DrawableHitObject h)
@@ -42,6 +57,15 @@ namespace osu.Game.Rulesets.Hishigata.UI
                 hitExplosionContainer.Add(hitExplosionPool.Get(e => e.Apply(h as DrawableHishigataHitObject)));
             Console.WriteLine(judgement.Type.ToString());
         }
+
+        private void registerPool<TObject, TDrawable>(int initialSize, int? maximumSize = null)
+            where TObject : HitObject
+            where TDrawable : DrawableHitObject, new()
+            => RegisterPool<TObject, TDrawable>(CreatePool<TDrawable>(initialSize, maximumSize));
+
+        protected virtual DrawablePool<TDrawable> CreatePool<TDrawable>(int initialSize, int? maximumSize = null)
+            where TDrawable : DrawableHitObject, new()
+            => new DrawableHishigataPool<TDrawable>(checkHittable, initialSize, maximumSize);
 
         public class LaneReceptor : CompositeDrawable
         {

--- a/osu.Game.Rulesets.Hishigata/UI/Lane.cs
+++ b/osu.Game.Rulesets.Hishigata/UI/Lane.cs
@@ -67,6 +67,8 @@ namespace osu.Game.Rulesets.Hishigata.UI
             where TDrawable : DrawableHitObject, new()
             => new DrawableHishigataPool<TDrawable>(checkHittable, initialSize, maximumSize);
 
+        protected override HitObjectLifetimeEntry CreateLifetimeEntry(HitObject hitObject) => new HishigataHitObjectLifetimeEntry(hitObject);
+
         public class LaneReceptor : CompositeDrawable
         {
             public int ID { get; set; }

--- a/osu.Game.Rulesets.Hishigata/UI/Lane.cs
+++ b/osu.Game.Rulesets.Hishigata/UI/Lane.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Hishigata.UI
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             AddRangeInternal(new Drawable[]{
-                hitExplosionPool = new DrawablePool<PoolableHitExplosion>(5),
+                hitExplosionPool = new DrawablePool<PoolableHitExplosion>(3),
                 hitExplosionContainer = new Container(),
                 HitObjectContainer,
                 new LaneReceptor{ID = ID}
@@ -55,7 +55,6 @@ namespace osu.Game.Rulesets.Hishigata.UI
         {
             if (judgement.IsHit)
                 hitExplosionContainer.Add(hitExplosionPool.Get(e => e.Apply(h as DrawableHishigataHitObject)));
-            Console.WriteLine(judgement.Type.ToString());
         }
 
         private void registerPool<TObject, TDrawable>(int initialSize, int? maximumSize = null)


### PR DESCRIPTION
With the initial steps for DHO pooling happening osu!-side, I thought I should familiarize myself with the whole procedure using this relatively straightforward ruleset, before doing it on sentakki.

--

All seems pretty straight forward. The only thing that may pose some resistance in the future would be the `HitObjectLifetimeEntry`.
The `InitialLifetimeOffset` and in turn `LifetimeStart` is variable, adjustable via an "AnimationSpeed" slider in the ruleset options. 

So to leave future me a method to look into:
Add the AnimationDuration bindable within the HOLE, and remove it from the DHO entirely. The bindables will still update accordingly, therefore affecting the lifetimes of the associated DHO.