### PR TITLE
Switch to .NET 6

### DIFF
--- a/osu.Game.Rulesets.Hishigata/osu.Game.Rulesets.Hishigata.csproj
+++ b/osu.Game.Rulesets.Hishigata/osu.Game.Rulesets.Hishigata.csproj
@@ -10,6 +10,6 @@
     <AssemblyName>osu.Game.Rulesets.Hishigata</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2022.1205.0"/>
+    <PackageReference Include="ppy.osu.Game" Version="2023.419.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game.Rulesets.Hishigata/osu.Game.Rulesets.Hishigata.csproj
+++ b/osu.Game.Rulesets.Hishigata/osu.Game.Rulesets.Hishigata.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Project">
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyTitle>osu.Game.Rulesets.Hishigata</AssemblyTitle>
     <OutputType>Library</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Resolves build issues with current versions of osu!lazer as osu.Game (and others) now targets .NET Core 6.
As far as testing goes (tested on an iOS build with this ruleset + 2 other custom rulesets), no problems have arisen from this change.
Also bumps ppy.osu.Game to the latest release (2023.419.0) as of the time of writing.