### PR TITLE
IApplicableToHitObject Trustworthy Mod

### DIFF
--- a/osu.Game.Rulesets.Hishigata/Beatmaps/HishigataBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Hishigata/Beatmaps/HishigataBeatmapConverter.cs
@@ -35,8 +35,7 @@ namespace osu.Game.Rulesets.Hishigata.Beatmaps
             float angle = getHitObjectAngle(position) / 90;
             int lane = (int)Math.Round(angle);
 
-            bool isFeign = false;
-            isFeign = original.Samples.Any(x => x.Name == HitSampleInfo.HIT_WHISTLE);
+            bool isFeign = original.Samples.Any(x => x.Name == HitSampleInfo.HIT_WHISTLE);
 
             if (lane >= 4) lane -= 4;
             switch (original)

--- a/osu.Game.Rulesets.Hishigata/Beatmaps/HishigataBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Hishigata/Beatmaps/HishigataBeatmapConverter.cs
@@ -25,9 +25,6 @@ namespace osu.Game.Rulesets.Hishigata.Beatmaps
         // https://github.com/ppy/osu/tree/master/osu.Game/Rulesets/Objects/Types
         public override bool CanConvert() => Beatmap.HitObjects.All(x => x is IHasPosition);
 
-        // trustworthy mod
-        public bool FeignsAllowed { get; set; } = true;
-
         protected override IEnumerable<HishigataHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap, CancellationToken cancellationToken)
         {
             var difficulty = beatmap.BeatmapInfo.Difficulty;
@@ -39,10 +36,7 @@ namespace osu.Game.Rulesets.Hishigata.Beatmaps
             int lane = (int)Math.Round(angle);
 
             bool isFeign = false;
-            if (FeignsAllowed)
-            {
-                isFeign = original.Samples.Any(x => x.Name == HitSampleInfo.HIT_WHISTLE);
-            }
+            isFeign = original.Samples.Any(x => x.Name == HitSampleInfo.HIT_WHISTLE);
 
             if (lane >= 4) lane -= 4;
             switch (original)

--- a/osu.Game.Rulesets.Hishigata/Mods/HishigataModInvert.cs
+++ b/osu.Game.Rulesets.Hishigata/Mods/HishigataModInvert.cs
@@ -21,8 +21,7 @@ namespace osu.Game.Rulesets.Hishigata.Mods
 
         public void ApplyToHitObject(HitObject hitObject)
         {
-            var hishigataHitObject = (HishigataHitObject)hitObject;
-            if (hishigataHitObject is HishigataNote hishigataNote) hishigataNote.IsFeign = !hishigataNote.IsFeign;
+            if (hitObject is HishigataNote hishigataNote) hishigataNote.IsFeign = !hishigataNote.IsFeign;
         }
     }
 }

--- a/osu.Game.Rulesets.Hishigata/Mods/HishigataModTrustworthy.cs
+++ b/osu.Game.Rulesets.Hishigata/Mods/HishigataModTrustworthy.cs
@@ -20,8 +20,7 @@ namespace osu.Game.Rulesets.Hishigata.Mods
 
         public void ApplyToHitObject(HitObject hitObject)
         {
-            HishigataHitObject hishigataHitObject = (HishigataHitObject)hitObject;
-            if (hishigataHitObject is HishigataNote hishigataNote) hishigataNote.IsFeign = false;
+            if (hitObject is HishigataNote hishigataNote) hishigataNote.IsFeign = false;
         }
     }
 }

--- a/osu.Game.Rulesets.Hishigata/Mods/HishigataModTrustworthy.cs
+++ b/osu.Game.Rulesets.Hishigata/Mods/HishigataModTrustworthy.cs
@@ -1,14 +1,14 @@
 using System;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Hishigata.Localisation.Mods;
-using osu.Game.Rulesets.Hishigata.Beatmaps;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Hishigata.Objects;
 
 namespace osu.Game.Rulesets.Hishigata.Mods
 {
-    public class HishigataModTrustworthy : Mod, IApplicableToBeatmapConverter
+    public class HishigataModTrustworthy : Mod, IApplicableToHitObject
     {
         public override string Name => "Trustworthy";
         public override string Acronym => "TW";
@@ -18,10 +18,10 @@ namespace osu.Game.Rulesets.Hishigata.Mods
         public override Type[] IncompatibleMods => new[] { typeof(HishigataModInvert) };
         public override IconUsage? Icon => FontAwesome.Solid.Check;
 
-        public void ApplyToBeatmapConverter(IBeatmapConverter beatmapConverter)
+        public void ApplyToHitObject(HitObject hitObject)
         {
-            var converter = (HishigataBeatmapConverter)beatmapConverter;
-            converter.FeignsAllowed = false;
+            HishigataHitObject hishigataHitObject = (HishigataHitObject)hitObject;
+            if (hishigataHitObject is HishigataNote hishigataNote) hishigataNote.IsFeign = false;
         }
     }
 }

--- a/osu.Game.Rulesets.Hishigata/Mods/HishigataModTrustworthy.cs
+++ b/osu.Game.Rulesets.Hishigata/Mods/HishigataModTrustworthy.cs
@@ -16,7 +16,9 @@ namespace osu.Game.Rulesets.Hishigata.Mods
         public override double ScoreMultiplier => 0.8;
         public override ModType Type => ModType.Conversion;
         public override Type[] IncompatibleMods => new[] { typeof(HishigataModInvert) };
-        public override IconUsage? Icon => FontAwesome.Solid.Check;
+        //Current Mod Icon is a check mark, however looks ugly and does not match other Icons,
+        // so needs updating. Perhaps making it smaller somehow would be enough?
+        //public override IconUsage? Icon => FontAwesome.Solid.Check;
 
         public void ApplyToHitObject(HitObject hitObject)
         {


### PR DESCRIPTION
Changed the Trustworthy Mod to be IApplicableToHitObject rather than IApplicableToBeatmapConverter.

Besides the fact that removing feigns by tracking through each Hit Object individually and ensuring that it is not a feign feels more natural than simply telling the Beatmap Converter not to include any during the conversion, this method also allows the Mod to work correctly on hypothetical Hishigata format maps which do not get converted where the current method does not.